### PR TITLE
formatting css

### DIFF
--- a/src/styleair.css
+++ b/src/styleair.css
@@ -16,15 +16,13 @@ body {
     box-sizing: border-box;
 }
 
-
 .hero--text {
-    
     font-weight: 600;
     font-size: 36px;
     color: #000000;
 }
 
-.hero--description{
+.hero--description {
     width: 320px;
     height: 56px;
     font-family: 'Poppins';
@@ -34,38 +32,45 @@ body {
     line-height: 110%;
     color: #222222;
 }
-section{
+
+section {
     padding: 20px;
     align-items: center;
 }
-.hero{
- display: flex;
- flex-direction: column;  
+
+.hero {
+     display: flex;
+     flex-direction: column;  
 }
-.card{
+
+.card {
     margin-left: 50px;
     width: 175px;
     font-size: 12px;
 }
 
-.card--image{
+.card--image {
     width: 100%;
     border-radius: 9px;
+}
 
+.card--stats {
+    display: flex;
+    align-items: center;
 }
-.card--stats{
-display: flex;
-align-items: center;
-}
-.card--star{
+
+.card--star {
     height: 14px;
 }
-.gray{
+
+.gray {
     color: #918e9B;
 }
-.bold{
+
+.bold {
     font-weight: bold;
 }
-.cards--div{
+
+.cards--div {
     display: flex;
 }


### PR DESCRIPTION
remove unnecessary lines inside css {}
add empty line before new css class
space before _{ like  .name { .... }
same indents - use tab inside {}